### PR TITLE
changes for ios pip

### DIFF
--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.h
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.h
@@ -3,6 +3,16 @@
 // found in the LICENSE file.
 
 #import <Flutter/Flutter.h>
+#import <AVFoundation/AVFoundation.h>
 
 @interface FLTVideoPlayerPlugin : NSObject <FlutterPlugin>
+@property(readonly, strong, nonatomic) NSMutableDictionary* players;
+@end
+
+@interface FLTVideoPlayer : NSObject <FlutterTexture, FlutterStreamHandler>
+@property(readonly, nonatomic) AVPlayer* player;
+@property(nonatomic) bool isPipActive;
+- (void)play;
+- (void)pause;
+- (void)setIsPipActive:(bool)isPipActive;
 @end

--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -35,8 +35,7 @@ int64_t FLTCMTimeToMillis(CMTime time) {
 }
 @end
 
-@interface FLTVideoPlayer : NSObject <FlutterTexture, FlutterStreamHandler>
-@property(readonly, nonatomic) AVPlayer* player;
+@interface FLTVideoPlayer ()
 @property(readonly, nonatomic) AVPlayerItemVideoOutput* videoOutput;
 @property(readonly, nonatomic) CADisplayLink* displayLink;
 @property(nonatomic) FlutterEventChannel* eventChannel;
@@ -368,12 +367,14 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
   if (!_isInitialized) {
     return;
   }
-  if (_isPlaying) {
-    [_player play];
-  } else {
-    [_player pause];
+  if(!_isPipActive) {
+      if (_isPlaying) {
+          [_player play];
+      } else {
+          [_player pause];
+      }
+      _displayLink.paused = !_isPlaying;
   }
-  _displayLink.paused = !_isPlaying;
 }
 
 - (void)sendInitialized {
@@ -544,7 +545,6 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 @interface FLTVideoPlayerPlugin () <FLTVideoPlayerApi>
 @property(readonly, weak, nonatomic) NSObject<FlutterTextureRegistry>* registry;
 @property(readonly, weak, nonatomic) NSObject<FlutterBinaryMessenger>* messenger;
-@property(readonly, strong, nonatomic) NSMutableDictionary* players;
 @property(readonly, strong, nonatomic) NSObject<FlutterPluginRegistrar>* registrar;
 @end
 

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -263,7 +263,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
 
   /// This is just exposed for testing. It shouldn't be used by anyone depending
   /// on the plugin.
-  @visibleForTesting
   int get textureId => _textureId;
 
   /// Attempts to open the given [dataSource] and load metadata about the video.


### PR DESCRIPTION
textureID чтобы знать по какому индексу тянуть плеерснял приватность с методов FLTPlayer и Самого плагниа чтобы достать этот самый плеер
Добавил флаг isPipActive чтобы в pip режиме не ставилось на пауза (fltPlayer при выходе ставится и не дает вложенному плееру играть)