### PR TITLE
fix: playback speed on resetting seekto

### DIFF
--- a/packages/video_player/video_player/example/lib/main.dart
+++ b/packages/video_player/video_player/example/lib/main.dart
@@ -6,7 +6,6 @@
 
 /// An example of using the plugin, controlling lifecycle and playback of the
 /// video.
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
@@ -56,7 +55,7 @@ class _App extends StatelessWidget {
         ),
         body: TabBarView(
           children: <Widget>[
-            _BumbleBeeRemoteVideo(),
+            const _RemoteVideo(),
             _ButterFlyAssetVideo(),
             _ButterFlyAssetVideoInList(),
           ],
@@ -200,6 +199,23 @@ class _ButterFlyAssetVideoState extends State<_ButterFlyAssetVideo> {
   }
 }
 
+class _RemoteVideo extends StatelessWidget {
+  const _RemoteVideo({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      children: [
+        _BumbleBeeRemoteVideo(),
+        const SizedBox(
+          height: 20,
+        ),
+        const _BigBuckBunnyVideo(),
+      ],
+    );
+  }
+}
+
 class _BumbleBeeRemoteVideo extends StatefulWidget {
   @override
   _BumbleBeeRemoteVideoState createState() => _BumbleBeeRemoteVideoState();
@@ -239,28 +255,85 @@ class _BumbleBeeRemoteVideoState extends State<_BumbleBeeRemoteVideo> {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      child: Column(
-        children: <Widget>[
-          Container(padding: const EdgeInsets.only(top: 20.0)),
-          const Text('With remote mp4'),
-          Container(
-            padding: const EdgeInsets.all(20),
-            child: AspectRatio(
-              aspectRatio: _controller.value.aspectRatio,
-              child: Stack(
-                alignment: Alignment.bottomCenter,
-                children: <Widget>[
-                  VideoPlayer(_controller),
-                  ClosedCaption(text: _controller.value.caption.text),
-                  _ControlsOverlay(controller: _controller),
-                  VideoProgressIndicator(_controller, allowScrubbing: true),
-                ],
-              ),
+    return Column(
+      children: <Widget>[
+        Container(padding: const EdgeInsets.only(top: 20.0)),
+        const Text('With remote mp4'),
+        Container(
+          padding: const EdgeInsets.all(20),
+          child: AspectRatio(
+            aspectRatio: _controller.value.aspectRatio,
+            child: Stack(
+              alignment: Alignment.bottomCenter,
+              children: <Widget>[
+                VideoPlayer(_controller),
+                ClosedCaption(text: _controller.value.caption.text),
+                _ControlsOverlay(controller: _controller),
+                VideoProgressIndicator(_controller, allowScrubbing: true),
+              ],
             ),
           ),
-        ],
-      ),
+        ),
+      ],
+    );
+  }
+}
+
+class _BigBuckBunnyVideo extends StatefulWidget {
+  const _BigBuckBunnyVideo({Key? key}) : super(key: key);
+
+  @override
+  _BigBuckBunnyVideoState createState() => _BigBuckBunnyVideoState();
+}
+
+class _BigBuckBunnyVideoState extends State<_BigBuckBunnyVideo> {
+  late VideoPlayerController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = VideoPlayerController.network(
+      'https://multiplatform-f.akamaihd.net/i/multi/will/bunny/big_buck_bunny_,640x360_400,640x360_700,640x360_1000,950x540_1500,.f4v.csmil/master.m3u8',
+      formatHint: VideoFormat.hls,
+      videoPlayerOptions: VideoPlayerOptions(),
+    );
+
+    _controller.addListener(() {
+      setState(() {});
+    });
+    _controller.setLooping(true);
+    _controller.initialize().then((_) => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        Container(
+          padding: const EdgeInsets.only(top: 20.0),
+        ),
+        const Text('With remote hls'),
+        Container(
+          padding: const EdgeInsets.all(20),
+          child: AspectRatio(
+            aspectRatio: _controller.value.aspectRatio,
+            child: Stack(
+              alignment: Alignment.bottomCenter,
+              children: <Widget>[
+                VideoPlayer(_controller),
+                _ControlsOverlay(controller: _controller),
+                VideoProgressIndicator(_controller, allowScrubbing: true),
+              ],
+            ),
+          ),
+        ),
+      ],
     );
   }
 }
@@ -377,8 +450,23 @@ class _ControlsOverlay extends StatelessWidget {
             ),
           ),
         ),
+        Align(
+          alignment: Alignment.bottomLeft,
+          child: IconButton(
+            onPressed: onPressed,
+            icon: const Icon(Icons.fast_forward),
+          ),
+        )
       ],
     );
+  }
+
+  Future<void> onPressed() async {
+    final Duration? currentDuration = await controller.position;
+    if (currentDuration != null) {
+      final Duration newDuration = currentDuration + const Duration(seconds: 1);
+      await controller.seekTo(newDuration);
+    }
   }
 }
 

--- a/packages/video_player/video_player/example/lib/main.dart
+++ b/packages/video_player/video_player/example/lib/main.dart
@@ -199,19 +199,48 @@ class _ButterFlyAssetVideoState extends State<_ButterFlyAssetVideo> {
   }
 }
 
-class _RemoteVideo extends StatelessWidget {
+class _RemoteVideo extends StatefulWidget {
   const _RemoteVideo({Key? key}) : super(key: key);
 
   @override
+  State<_RemoteVideo> createState() => _RemoteVideoState();
+}
+
+class _RemoteVideoState extends State<_RemoteVideo> {
+  List<bool> isSelected = [true, false];
+
+  @override
   Widget build(BuildContext context) {
-    return ListView(
-      children: [
-        _BumbleBeeRemoteVideo(),
-        const SizedBox(
-          height: 20,
-        ),
-        const _BigBuckBunnyVideo(),
-      ],
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 20.0),
+      child: Column(
+        children: [
+          ToggleButtons(
+            children: const <Widget>[
+              Text('MP4'),
+              Text('HLS'),
+            ],
+            onPressed: (int index) {
+              setState(() {
+                for (int buttonIndex = 0;
+                    buttonIndex < isSelected.length;
+                    buttonIndex++) {
+                  if (buttonIndex == index) {
+                    isSelected[buttonIndex] = true;
+                  } else {
+                    isSelected[buttonIndex] = false;
+                  }
+                }
+              });
+            },
+            isSelected: isSelected,
+          ),
+          if (isSelected[0])
+            _BumbleBeeRemoteVideo()
+          else
+            const _BigBuckBunnyVideo(),
+        ],
+      ),
     );
   }
 }
@@ -257,8 +286,6 @@ class _BumbleBeeRemoteVideoState extends State<_BumbleBeeRemoteVideo> {
   Widget build(BuildContext context) {
     return Column(
       children: <Widget>[
-        Container(padding: const EdgeInsets.only(top: 20.0)),
-        const Text('With remote mp4'),
         Container(
           padding: const EdgeInsets.all(20),
           child: AspectRatio(
@@ -315,10 +342,6 @@ class _BigBuckBunnyVideoState extends State<_BigBuckBunnyVideo> {
   Widget build(BuildContext context) {
     return Column(
       children: <Widget>[
-        Container(
-          padding: const EdgeInsets.only(top: 20.0),
-        ),
-        const Text('With remote hls'),
         Container(
           padding: const EdgeInsets.all(20),
           child: AspectRatio(

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -40,6 +40,7 @@
 @property(nonatomic, readonly) BOOL disposed;
 @property(nonatomic, readonly) BOOL isPlaying;
 @property(nonatomic) BOOL isLooping;
+@property(nonatomic) double currentPlaybackSpeed;
 @property(nonatomic, readonly) BOOL isInitialized;
 - (instancetype)initWithURL:(NSURL *)url
                frameUpdater:(FLTFrameUpdater *)frameUpdater
@@ -323,6 +324,7 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
   }
   if (_isPlaying) {
     [_player play];
+    [self setPlaybackSpeed:_currentPlaybackSpeed];
   } else {
     [_player pause];
   }
@@ -438,6 +440,7 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
     return;
   }
 
+  [self setCurrentPlaybackSpeed:speed];
   _player.rate = speed;
 }
 


### PR DESCRIPTION
SeekTo affected the video`s playback speed if it use stream source. If select not default platback speed (2.0x for example) and then use seekTo, playback speed automatically changes to default value. This pull request fix such behaviour.

Issue: https://github.com/flutter/flutter/issues/71264

How it works now:

https://user-images.githubusercontent.com/50741700/160338678-82e3fc43-8ce2-4e41-a890-bc6c92bd508d.mov


