### PR TITLE
fix: затащил старые изменения для пипа

### DIFF
--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -324,9 +324,8 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   static const int kUninitializedTextureId = -1;
   int _textureId = kUninitializedTextureId;
 
-  /// This is just exposed for testing. It shouldn't be used by anyone depending
-  /// on the plugin.
-  @visibleForTesting
+  /// Убрал аннотацию @visibleForTesting
+  /// Это поле нужно нам для PictureInPicture
   int get textureId => _textureId;
 
   /// Attempts to open the given [dataSource] and load metadata about the video.

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.h
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.h
@@ -3,7 +3,17 @@
 // found in the LICENSE file.
 
 #import <Flutter/Flutter.h>
+#import <AVFoundation/AVFoundation.h>
 
 @interface FLTVideoPlayerPlugin : NSObject <FlutterPlugin>
+@property(readonly, strong, nonatomic) NSMutableDictionary *playersByTextureId;
 - (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar;
+@end
+
+@interface FLTVideoPlayer : NSObject <FlutterTexture, FlutterStreamHandler>
+@property(readonly, nonatomic) AVPlayer* player;
+@property(nonatomic) bool isPipActive;
+- (void)play;
+- (void)pause;
+- (void)setIsPipActive:(bool)isPipActive;
 @end

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -30,7 +30,7 @@
 }
 @end
 
-@interface FLTVideoPlayer : NSObject <FlutterTexture, FlutterStreamHandler>
+@interface FLTVideoPlayer ()
 @property(readonly, nonatomic) AVPlayer *player;
 @property(readonly, nonatomic) AVPlayerItemVideoOutput *videoOutput;
 @property(readonly, nonatomic) CADisplayLink *displayLink;
@@ -345,13 +345,15 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
   if (!_isInitialized) {
     return;
   }
-  if (_isPlaying) {
-    [_player play];
-    [self setPlaybackSpeed:_currentPlaybackSpeed];
-  } else {
-    [_player pause];
+  if (!_isPipActive) {
+      if (_isPlaying) {
+        [_player play];
+        [self setPlaybackSpeed:_currentPlaybackSpeed];
+      } else {
+        [_player pause];
+      }
+      _displayLink.paused = !_isPlaying;
   }
-  _displayLink.paused = !_isPlaying;
 }
 
 - (void)setupEventSinkIfReadyToPlay {
@@ -540,8 +542,6 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
 @interface FLTVideoPlayerPlugin () <FLTAVFoundationVideoPlayerApi>
 @property(readonly, weak, nonatomic) NSObject<FlutterTextureRegistry> *registry;
 @property(readonly, weak, nonatomic) NSObject<FlutterBinaryMessenger> *messenger;
-@property(readonly, strong, nonatomic)
-    NSMutableDictionary<NSNumber *, FLTVideoPlayer *> *playersByTextureId;
 @property(readonly, strong, nonatomic) NSObject<FlutterPluginRegistrar> *registrar;
 @end
 


### PR DESCRIPTION
Изменение от декабря 2020. Чуть поменялись имена методов в новом плеере, поэтому надо будет у нас в пипе поправить метод `players` на `playersByTextureId` и импорт вместо `video_player` будет `video_player_avfoundation`

https://github.com/surfstudio/labelcom-flutter/blob/e5bb27ca1067fe352a9ce4c38dfaa8b8a18bac3a/ios/Runner/pip/pip_plugin.swift#L245